### PR TITLE
Fixed RF_ERRORS when APPLY_PRIOR=0

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -228,7 +228,7 @@ int main(int argc, char **argv) {
     }
 
     /////// Make sure BINARY_OUTPUT is set if computing RF color errors
-    if (RF_ERRORS && BINARY_OUTPUT==0 && READ_ZBIN==0)  {
+    if (RF_ERRORS && isdigit(REST_FILTERS[0]) && BINARY_OUTPUT==0 && READ_ZBIN==0)  {
         fprintf(stderr,"RF_ERRORS set, forcing BINARY_OUTPUT=1 ...\n");
         BINARY_OUTPUT=1;
     }

--- a/src/rest_frame_colors.c
+++ b/src/rest_frame_colors.c
@@ -330,10 +330,14 @@ void rest_frame_colors() {
         //// Do fit for coefficients at *all* redshifts
         if (RF_ERRORS) {
             
+            izbest = 0;
             if (APPLY_PRIOR) {
-                izbest = 0;
                 apply_prior(priorkz, NZ, NK_prior, izbest, chi2_fit_full,
                             fnu[iobj][PRIOR_FILTER_IDX], &izprior, pzout);
+            } else {
+                for (i=0;i<NZ;++i) {
+                    pzout[i] = exp(-0.5*(chi2_fit_full[i]-chi2_fit_full[izbest])/CHI2_SCALE);
+                }
             }
             
             //// Normalization of p(z), make pzout = pzout * dz so can sum directly


### PR DESCRIPTION
Hi Gabe. I just realized the last patch I wrote contained a mistake. In case RF_ERRORS=1 and APPLY_PRIOR=0 the variable ```pzout```  was not updated from one galaxy to the next... It was done in ```apply_prior()``` and I disabled that call when APPLY_PRIOR=0. Now I have added the missing piece of code, and this will work as expected. I must say, it is hard to track down what's going on given how many global variables you used ;) But the reason why I didn't see it before is because I was testing with a catalog of just one galaxy... Oops. My bad.